### PR TITLE
Fix sample code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Parse::Crontab - Perl extension to parse Vixie crontab file
 
     use Parse::Crontab;
     my $crontab = Parse::Crontab->new(file => 'crontab.txt');
-    if ($crontab->is_valid) {
-        warn $crontab->error_message;
+    unless ($crontab->is_valid) {
+        warn $crontab->error_messages;
     }
     for my $job ($crontab->jobs) {
         say $job->minute;

--- a/lib/Parse/Crontab.pm
+++ b/lib/Parse/Crontab.pm
@@ -145,8 +145,8 @@ Parse::Crontab - Perl extension to parse Vixie crontab file
 
     use Parse::Crontab;
     my $crontab = Parse::Crontab->new(file => 'crontab.txt');
-    if ($crontab->is_valid) {
-        warn $crontab->error_message;
+    unless ($crontab->is_valid) {
+        warn $crontab->error_messages;
     }
     for my $job ($crontab->jobs) {
         say $job->minute;


### PR DESCRIPTION
I had used this nice product. When I run sample code, I found very little typo.
So I modified only README.md & comment in code.
- Parse::Crontab has method, which is not `error_message` but `error_messages`.
- I think that if crontab does not valid, it should output warn.
